### PR TITLE
chore: 未使用の mocha-junit-reporter を依存から外す

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "gulp-terser": "^2.1.0",
         "licensify": "^3.1.3",
         "mocha": "^11.7.6",
-        "mocha-junit-reporter": "^2.2.1",
         "postcss": "^8.5.25",
         "sass": "^1.102.0",
         "through2": "^4.0.2",
@@ -4401,15 +4400,6 @@
         "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -4869,15 +4859,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/crypto-browserify": {
@@ -8074,17 +8055,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -8235,21 +8205,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -8291,22 +8246,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/mocha-junit-reporter": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.2.1.tgz",
-      "integrity": "sha512-iDn2tlKHn8Vh8o4nCzcUVW4q7iXp7cC4EB78N0cDHIobLymyHNwe0XG8HEHHjc3hJlXm0Vy6zcrxaIhnI2fWmw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "md5": "^2.3.0",
-        "mkdirp": "^3.0.0",
-        "strip-ansi": "^6.0.1",
-        "xml": "^1.0.1"
-      },
-      "peerDependencies": {
-        "mocha": ">=2.2.5"
       }
     },
     "node_modules/mocha/node_modules/balanced-match": {
@@ -11859,12 +11798,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
-      "dev": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "gulp-terser": "^2.1.0",
     "licensify": "^3.1.3",
     "mocha": "^11.7.6",
-    "mocha-junit-reporter": "^2.2.1",
     "postcss": "^8.5.25",
     "sass": "^1.102.0",
     "through2": "^4.0.2",


### PR DESCRIPTION
## 概要

- devDependencies から `mocha-junit-reporter` を削除する

## 背景

knip + depcheck のクロスチェックで未使用と判定された依存の棚卸しタスクの一つ。
`test` スクリプトは `mocha --exit --require @babel/register "test/test_*.js"` で reporter 指定が無く、`.mocharc` 系の設定ファイルも存在しない。CI (`.github/workflows/ci.yml`) も `npm test` を素で実行するだけで JUnit 出力を消費していない。

同じ確定候補にあった `bundle-collapser` は誤検知（`gulpfile.babel.js` の `.plugin('bundle-collapser/plugin')` で実際に使用中）で対象外、`core-js` は別タスクで対応予定のため今回のスコープには含めない。

## Test plan

- [x] `npm install` でロックファイルを更新（873 → 872 パッケージ）
- [x] `npm test` 39 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)