### PR TITLE
refactor(style): 非推奨の Sass @import を @use へ置き換える

### DIFF
--- a/conf/config.sass
+++ b/conf/config.sass
@@ -1,3 +1,8 @@
 // テーマCSSのカスタマイズ (SASS形式)
+//
+// _default.sass の値を上書きする。@use では他のモジュールの変数を
+// default.$name: value の形で書き換える。app.sass が default -> config -> main... の
+// 順に @use しているので、上書きは main 以降の評価に反映される。
+@use 'default'
 
-$themeColor: #689B8C
+default.$themeColor: #689B8C

--- a/src/sass/_bottom.sass
+++ b/src/sass/_bottom.sass
@@ -1,4 +1,6 @@
 @charset "utf-8"
+@use 'default' as *
+@use 'functions' as *
 
 /* ページネーション
 

--- a/src/sass/_functions.sass
+++ b/src/sass/_functions.sass
@@ -1,0 +1,18 @@
+@charset "utf-8"
+@use "sass:math"
+@use 'default' as *
+
+// _main.sass にあった rem()。
+// @import なら暗黙で全体から見えていたが、@use では読み込んだ側からしか見えない。
+// _main / _top / _side / _result / _bottom から使うのでここへ分けた。
+// CSS を出さないモジュールなので、@use する位置は出力順に影響しない。
+//
+// $standard-rem は呼び出し時に評価されるため、conf 側の config.sass が
+// 上書きした値がそのまま効く。
+
+// CSSフレームワークに対応するために演算済みのremを出力する
+@function rem($value)
+    @if $standard-rem == false
+        @return $value * 1rem
+    @else
+        @return math.div(math.ceil($value * 0.625 * 100), 100) * 1rem

--- a/src/sass/_main.sass
+++ b/src/sass/_main.sass
@@ -1,12 +1,6 @@
 @charset "utf-8"
-@use "sass:math"
-
-// CSSフレームワークに対応するために演算済みのremを出力する
-@function rem($value)
-    @if $standard-rem == false
-        @return $value * 1rem
-    @else
-        @return math.div(ceil($value * 0.625 * 100) , 100) * 1rem
+@use 'default' as *
+@use 'functions' as *
 
 *
     box-sizing: border-box

--- a/src/sass/_result.sass
+++ b/src/sass/_result.sass
@@ -1,4 +1,5 @@
 @charset "utf-8"
+@use 'functions' as *
 
 /* 検索結果
 .emresults

--- a/src/sass/_side.sass
+++ b/src/sass/_side.sass
@@ -1,4 +1,5 @@
 @charset "utf-8"
+@use 'functions' as *
 
 /* サイドバー
 .emside

--- a/src/sass/_top.sass
+++ b/src/sass/_top.sass
@@ -1,4 +1,6 @@
 @charset "utf-8"
+@use 'default' as *
+@use 'functions' as *
 @use "sass:math"
 
 /* トップ（検索ボックス）*/

--- a/src/sass/app.sass
+++ b/src/sass/app.sass
@@ -1,14 +1,14 @@
 @charset "utf-8"
 
-@import 'forced-color'
-@import 'default'
+@use 'forced-color'
+@use 'default'
 
-@import 'config'
+@use 'config'
 
-@import 'main'
-@import 'top'
-@import 'side'
-@import 'result'
-@import 'bottom'
+@use 'main'
+@use 'top'
+@use 'side'
+@use 'result'
+@use 'bottom'
 
-@import 'index'
+@use 'index'


### PR DESCRIPTION
## なぜ

Dart Sass は `@import` を非推奨にしており、**Dart Sass 3.0 で削除**される。
CALIL org 全体では31リポジトリ・247行が該当し、うち active は17リポジトリ・193行。
このPRはその一部。

## unitrad 系がやっていること

`src/sass/app.sass` を、サイトごとの `conf/<site>/` を include path に足して
コンパイルする構成。`config` と `index` はサイト側から解決される。
`_default.sass` の変数をサイトの `config.sass` が上書きしてテーマを差し替えている。

この「後から読み込んだファイルが変数を上書きする」形は `@import` の
グローバルスコープに依存しているので、単純に `@use` へ置き換えると壊れる。

## どう直したか

**変数の上書きは `default.$name: value` にした。**
`@use` では他のモジュールの変数をこの形で書き換えられる。`app.sass` が
`default` → `config` → `main` … の順に `@use` するので、`config` での上書きは
`main` 以降の評価に反映される。

```sass
# conf/<site>/config.sass
@use 'default'
default.$themeColor: #689B8C
```

**`rem()` は `_functions.sass` に分けた。**
`_main.sass` で定義され `_top` / `_side` / `_result` / `_bottom` などから
使われていた。`@use` では読み込んだ側からしか見えないので、CSS を出さない
モジュールに分けて使う側が `@use 'functions' as *` する。
CSS を出さないので `@use` の位置は出力順に影響しない。
`$standard-rem` は関数の呼び出し時に評価されるため、`config.sass` の上書きも効く。

**`app.sass` は `@import` を `@use` に置き換えるだけ。**
`app.sass` は `@charset` しか持たず自分の規則が無いので、読み込み順は変わらない。
## このリポジトリでの結果

- 対象は `conf/` の1サイト。コンパイルした CSS は移行前と **SHA256 まで一致**
- DEPRECATION WARNING は **0件**

あわせて `rem()` の `ceil()` を `math.ceil()` にした（Dart Sass 3.0 で削除されるため）。
17個の値（負数・小数含む）で旧実装と一致することを確認している。
🤖 Generated with [Claude Code](https://claude.com/claude-code)
