### PR TITLE
コード内コメントから顧客名を除去する

### DIFF
--- a/src/js/view/index.tsx
+++ b/src/js/view/index.tsx
@@ -204,7 +204,7 @@ export default class Index extends React.Component<Props, State> {
   }
 
   onPressKey(word: string) {
-    /* 砺波こども用のためのコード */
+    /* ソフトキーボード連携用のコード */
     console.log("inside:" + word);
     let freeword = this.state.query.free || '';
     if (word === '[bs]') {


### PR DESCRIPTION
## 概要

PR #71で移植したコメントに、特定顧客(自治体)名がそのまま残っていました。オープンソース版に顧客名を含めるべきではないため、一般的な説明に書き換えます。機能・挙動の変更はありません。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TBuCdY1AzZrVnRHRXUkLyG