### PR TITLE
fix: sort.ts/request.tsの表記をunitrad-viewに揃える

### DIFF
--- a/src/js/request.ts
+++ b/src/js/request.ts
@@ -15,8 +15,8 @@
    request.get(url).query({a: 1}).end((err, res) => { res.body })
    request.get(url).then((res) => res.body)
 
- esbuildのaliasで 'superagent' をこのモジュールへ向けているため、サイト設定は
- 書き換えていない。superagentとの差で気をつける点は3つ:
+ esbuildのaliasで 'superagent' をこのモジュールへ向けているため、2600件以上ある
+ サイト設定は書き換えていない。superagentとの差で気をつける点は3つ:
    - fetchは4xx/5xxでもresolveするので、okでなければerrにして返す
    - res.body はJSONのときだけパース結果を入れる（superagentと同じくそれ以外は空オブジェクト）
    - res.text は常に生の本文

--- a/src/js/sort.ts
+++ b/src/js/sort.ts
@@ -204,7 +204,7 @@ export function normalizeIsbn(isbn: string): string {
   if (!isbn) return '';
   const _tmp = isbn.replace(/[-]+/g, '');
   if (_tmp.length <= 10) {
-    return "   " + _tmp;
+    return "\u2002\u2002\u2002" + _tmp;
   }
   return _tmp;
 }


### PR DESCRIPTION
## Summary
- unitrad-viewとunitrad-uiのsrcを横断比較したところ、`js/sort.ts` のISBN整形の空白表記と `js/request.ts` のコメントがview側から分岐していたので揃えた
- `sort.ts:207` — ISBN整形の空白を実際のU+2002文字3つから、view側と同じ `\u2002` エスケープ表記のリテラルテキストに変更（見た目の空白は変わらない）
- `request.ts:18-19` — コメントの「2600件以上ある」という文言をviewに合わせて追加

## Note
`request.ts` の「2600件以上ある」はunitrad-view側の実際のconf件数（2,490件程度）に基づく記述で、unitrad-ui側は `conf/` が5件のみのため、この数値はunitrad-uiの実態とは一致しない。今回はview側の表記に揃える指示のためそのまま反映しているが、コメントの正確性が気になる場合は別途調整を検討してほしい。

## Test plan
- [ ] `npm test` / `npm run typecheck` が通ることを確認