### PR TITLE
chore: ライセンスヘッダのURL解決を spdx-license-list へ置き換える

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,9 @@
         "esbuild": "^0.28.1",
         "jsdom": "^30.0.1",
         "minimist": "^1.2.8",
-        "oss-license-name-to-url": "^1.2.1",
         "postcss": "^8.5.25",
         "sass-embedded": "^1.100.0",
+        "spdx-license-list": "^6.12.0",
         "typescript": "^7.0.2"
       },
       "engines": {
@@ -2274,25 +2274,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/osi-licenses": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/osi-licenses/-/osi-licenses-0.1.1.tgz",
-      "integrity": "sha512-ZGAGO6dIxTS/mXxEJCpIdYetAoxIOOr7uYpMOoDWo4+b/6rf+2GagOjTbegL+eoMI8aYAiyNgKWUT7vWJRPl9A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10",
-        "npm": ">=1.2"
-      }
-    },
-    "node_modules/oss-license-name-to-url": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/oss-license-name-to-url/-/oss-license-name-to-url-1.2.1.tgz",
-      "integrity": "sha512-apFbKq0EAYi70q0pOpS0tDfSviZYdG3KM6U1GpofZPsRMwgDga0DQiPQ/GHyQx7PDDrLCGvFBNPLMLV/K4Jr4Q==",
-      "dev": true,
-      "dependencies": {
-        "osi-licenses": "^0.1.0"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3381,6 +3362,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spdx-license-list": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-6.12.0.tgz",
+      "integrity": "sha512-+nUYqm3aZMSHbjsthK+i/HHI2okTElCvqwUd4k8QcSk+FTGgjq+fsdFj2wZOaX6XmR2JdWhf/NeflNnvKOjcnQ==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stylehacks": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "esbuild": "^0.28.1",
     "jsdom": "^30.0.1",
     "minimist": "^1.2.8",
-    "oss-license-name-to-url": "^1.2.1",
     "postcss": "^8.5.25",
     "sass-embedded": "^1.100.0",
+    "spdx-license-list": "^6.12.0",
     "typescript": "^7.0.2"
   },
   "repository": {

--- a/tools/lib/license-header.mjs
+++ b/tools/lib/license-header.mjs
@@ -3,28 +3,45 @@ import path from 'node:path';
 import {createRequire} from 'node:module';
 
 const require = createRequire(import.meta.url);
-const nameToUrl = require('oss-license-name-to-url');
+const spdxLicenseList = require('spdx-license-list');
 
 /*
  バンドルに含まれた依存ライブラリのライセンス一覧をヘッダとして出力する。
- licensify（browserifyプラグイン）のextract / createEachHeaderの仕様に合わせてあり、
- URL付与も同じ oss-license-name-to-url を使う。
+ licensify（browserifyプラグイン）のextract / createEachHeaderの仕様に合わせてある。
 
- 収集対象だけがlicensifyと異なる:
+ licensifyと異なる点が2つある。
+
+ ひとつは収集対象:
    licensify … 依存グラフを歩く途中で見つけたpackage.json全部。Node互換shim（process /
      timers-browserify / browser-resolve）や、最終出力に残らないreact-dom開発版も含む
    こちら   … metafileのinputsに実際に入ったファイルの所属パッケージのみ
  実際に配布されるコードのライセンスを列挙する点でこちらが正確。
+
+ もうひとつはURLの引き方。licensifyが使うoss-license-name-to-urlは2015年で更新が
+ 止まっており、0BSD / MIT-0 / BlueOak-1.0.0 のようにその後SPDXへ登録された識別子を
+ 解決できずURLなしになる。こちらはSPDXの一覧をそのまま引く。
  */
 
 const PROPS = ['license', 'licenses', 'author', 'maintainers', 'contributors', 'homepage', 'version'];
 const OPERATORS = ['OR', 'AND'];
 
+/* SPDXの識別子は大文字小文字を区別せずに照合する決まりなので、小文字で引けるようにする */
+const spdxIds = new Map(Object.keys(spdxLicenseList).map((id) => [id.toLowerCase(), id]));
+
 const isPlainObject = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+/*
+ spdx-license-listが持つurlはライセンスごとに提供元がばらつく（ISCはisc.orgの一覧ページ、
+ 0BSDは個人サイト）ため、識別子の確認だけに使い、URLはSPDXの公式ページへ揃える。
+ */
+function licenseUrl(name) {
+  const id = spdxIds.get(name.toLowerCase());
+  return id ? `https://spdx.org/licenses/${id}.html` : null;
+}
 
 function appendUrlToLicense(name) {
   if (!name) return name;
-  const url = nameToUrl(name);
+  const url = licenseUrl(name);
   return url ? `${name} (${url})` : name;
 }
 


### PR DESCRIPTION
## 背景

`oss-license-name-to-url` は 2015-05-31 のリリースを最後に更新が止まっていて、GitHub 側も archived です。脆弱性の報告はありませんが、SPDX 識別子から URL へのマッピングが11年前のままなので、その後に登録された識別子を解決できずヘッダに URL が付きません。

`tools/lib/license-header.mjs` がこれを使ってリリースビルドのライセンスヘッダに URL を付けています。同じファイルを unitrad-ui / unitrac-ui / unitrad-view / unitrad-ui-nagano / unitrad-kintone-plugin の5リポジトリが1バイト違わず持っているので、同じ変更をまとめて入れています。

## 変更内容

SPDX 公式データの写しである `spdx-license-list` に置き換えました。識別子の確認だけに使い、URL は `https://spdx.org/licenses/<ID>.html` を組み立てています。

`spdx-license-list` 自体も `url` フィールドを持っていますが、これは「ライセンス本文の置き場」で、ライセンスごとに提供元がばらつきます。ISC は isc.org の一覧ページ、Apache-2.0 は apache.org、0BSD は個人サイトかつ http のままです。現行が `opensource.org/licenses/<ID>` で揃っていた性格を引き継ぎたいので、SPDX 側のページに統一しました。

旧実装が持っていた `bsd` → `BSD-2-Clause` のような非SPDX表記のエイリアスは引き継いでいません。5リポジトリの全依存にその表記が1件も無いこと、`gpl` → `GPL-3.0` のような推測が正しい保証も無いためです。SPDX 側は `GPL-3.0` のような deprecated 識別子も持っているので、古い package.json でよく見る表記はそのまま解決できます。

## 出力の変化

リリースビルドのヘッダの差分は URL の行だけです。ヘッダのバイト数も変わりません（`http://opensource.org/licenses/MIT` と `https://spdx.org/licenses/MIT.html` がどちらも34文字のため）。

```diff
  * react:
- *   license: MIT (http://opensource.org/licenses/MIT)
+ *   license: MIT (https://spdx.org/licenses/MIT.html)
  *   homepage: https://reactjs.org/
  *   version: 18.3.1
```

5リポジトリのバンドルに実際に入るのは自リポジトリ + react + react-dom + react-paginate + scheduler で、いずれも MIT です。そのため実際の成果物では上記の1行が繰り返し変わるだけになります。

### 依存ツリー全体での突き合わせ

バンドルに入らないものも含めて、`node_modules` に実在するライセンス名を全件、置き換え前後で比較しました。**URL が付かなくなるものは1件もありません。**

URL の形が変わるもの:

| 識別子 | before | after |
|---|---|---|
| MIT | `http://opensource.org/licenses/MIT` | `https://spdx.org/licenses/MIT.html` |
| Apache-2.0 | `http://opensource.org/licenses/Apache-2.0` | `https://spdx.org/licenses/Apache-2.0.html` |
| ISC | `http://opensource.org/licenses/ISC` | `https://spdx.org/licenses/ISC.html` |
| BSD-2-Clause | `http://opensource.org/licenses/BSD-2-Clause` | `https://spdx.org/licenses/BSD-2-Clause.html` |
| BSD-3-Clause | `http://opensource.org/licenses/BSD-3-Clause` | `https://spdx.org/licenses/BSD-3-Clause.html` |
| CC0-1.0 | `http://creativecommons.org/publicdomain/zero/1.0/` | `https://spdx.org/licenses/CC0-1.0.html` |

新しく URL が付くもの（現行は `null` で、ライセンス名だけがヘッダに出ていた）:

| 識別子 | after |
|---|---|
| 0BSD | `https://spdx.org/licenses/0BSD.html` |
| MIT-0 | `https://spdx.org/licenses/MIT-0.html` |
| BlueOak-1.0.0 | `https://spdx.org/licenses/BlueOak-1.0.0.html` |
| CC-BY-4.0 | `https://spdx.org/licenses/CC-BY-4.0.html` |
| CC-BY-3.0 | `https://spdx.org/licenses/CC-BY-3.0.html` |
| Unlicense | `https://spdx.org/licenses/Unlicense.html` |

これが「11年古い」の実害そのものです。旧実装は `osi-licenses` が持つ69件の OSI 一覧（2015年時点）だけを参照していて、そこに無い識別子は問答無用で `null` を返していました。SPDX 側は現在 727 件を持っています。

## 確認したこと

- 5リポジトリすべてで `npm run release` が通り、ヘッダの差分が URL の行だけであること（`unitrac-ui` は `--all` で4サイト分すべて確認）
- `npm run typecheck` と `npm test` がグリーン（5リポジトリ合計 773 件）
- lockfile の差分が `oss-license-name-to-url` と `osi-licenses` の削除、`spdx-license-list` の追加だけで、他の依存に巻き添えが無いこと
- リポジトリ内に `oss-license-name-to-url` / `osi-licenses` / `opensource.org` への参照が残っていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTMgXN4xUWD4LhkQtHhiGe
