### PR TITLE
tsconfig を strict にする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-paginate": "8.3.0"
       },
       "devDependencies": {
+        "@types/jsdom": "^30.0.0",
         "@types/node": "^22.20.1",
         "@types/react": "^18.3.31",
         "@types/react-dom": "^18.3.7",
@@ -1033,6 +1034,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-30.0.0.tgz",
+      "integrity": "sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^8.9.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.10.0.tgz",
+      "integrity": "sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -1070,6 +1091,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
@@ -2096,19 +2124,6 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/jsdom/node_modules/lru-cache": {
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -2117,19 +2132,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/jsdom/node_modules/parse5": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^8.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsdom/node_modules/punycode": {
@@ -2283,6 +2285,32 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "test"
   },
   "devDependencies": {
+    "@types/jsdom": "^30.0.0",
     "@types/node": "^22.20.1",
     "@types/react": "^18.3.31",
     "@types/react-dom": "^18.3.7",

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -165,7 +165,7 @@ export function isEmptyQuery(query: UnitradQuery | null | undefined): boolean {
  * @param q2 比較先クエリ
  * @returns {boolean}
  */
-export function isEqualQuery(q1: UnitradQuery, q2: UnitradQuery): boolean {
+export function isEqualQuery(q1: UnitradQuery | null | undefined, q2: UnitradQuery | null | undefined): boolean {
   for (const k of FIELDS) {
     if (k === 'region') continue;
     if ((q1 && hasOwn(q1, k) ? (q1 as any)[k] : '') !== (q2 && hasOwn(q2, k) ? (q2 as any)[k] : '')) return false

--- a/src/js/sort.ts
+++ b/src/js/sort.ts
@@ -119,16 +119,19 @@ export function holdingsFromBook(book: UnitradBook, includes: Array<number>): nu
  * @param b {Array} 所蔵リスト
  * @returns {Array}
  */
-export function intersectHoldings(a: Array<number>, b: Array<number>): Array<number> {
+export function intersectHoldings(a: Array<number> | null | undefined, b: Array<number> | null | undefined): Array<number> {
   if (!a || !b) return [];
   return a.filter(x => b.indexOf(x) !== -1);
 }
 
-function _stringSorter(a: string, b: string): number {
+function _stringSorter(a: string | null | undefined, b: string | null | undefined): number {
   if (!b && a) return -1;
   if (!a && b) return 1;
-  if (a > b) return 1;
-  if (a < b) return -1;
+  /* ここに来るのは両方とも真か両方とも偽のときだけ。偽どうしは空文字にすると 0 になる */
+  const _a = a ?? '';
+  const _b = b ?? '';
+  if (_a > _b) return 1;
+  if (_a < _b) return -1;
   return 0;
 }
 
@@ -200,7 +203,7 @@ function pubdateSorter(a: UnitradBook, b: UnitradBook): number {
  * ・無効な桁数は空文字列を返す
  * @type {RegExp}
  */
-export function normalizeIsbn(isbn: string): string {
+export function normalizeIsbn(isbn: string | null | undefined): string {
   if (!isbn) return '';
   const _tmp = isbn.replace(/[-]+/g, '');
   if (_tmp.length <= 10) {
@@ -217,7 +220,7 @@ export function normalizeIsbn(isbn: string): string {
  * @param {String || Number} p
  * @returns {Number}
  */
-export function normalizePubdate(p: string | number): number {
+export function normalizePubdate(p: string | number | null | undefined): number {
   const _p = String(p).replace(/元年/g, "1年");
   const _tmp = _p.match(/\d+/g);
   if (_tmp) {

--- a/src/js/view/book.tsx
+++ b/src/js/view/book.tsx
@@ -12,9 +12,16 @@ import React from 'react';
 import {api} from '../api'
 import {processExcludes, unresolvedHoldings, countHoldings, intersectHoldings} from '../sort'
 
+/* doUpdate が組み立てる所蔵の集約。書誌の全項目は持たない */
+type BookDeep = {
+  url: { [key: string]: string },
+  holdings: Array<number>,
+  bid: { [key: string]: string }
+};
+
 type State = {
   uuid: string | null | undefined,
-  book_deep: UnitradBook | null | undefined,
+  book_deep: BookDeep | null | undefined,
   unresolvedHoldings: Array<number>,
   remains?: Array<string> | null
 };
@@ -53,7 +60,7 @@ export default class Book extends React.Component<Props, State> {
     if (this.props.opened && !this.api) {
       console.log('start deep search');
       this.api = new api({
-        isbn: this.props.book.isbn,
+        isbn: this.props.book.isbn ?? undefined,
         region: this.props.region
       }, this.doUpdate.bind(this));
     }
@@ -63,30 +70,29 @@ export default class Book extends React.Component<Props, State> {
     processExcludes(data.books, this.props.excludes);
 
     // 高精度化実験
-    let book_deep;
+    let book_deep: BookDeep | null;
     if (data.books.length >= 1) {
-      if (!book_deep) {
-        book_deep = {
-          url: {},
-          holdings: [],
-          bid: {}
-        };
-      }
+      const deep: BookDeep = {
+        url: {},
+        holdings: [],
+        bid: {}
+      };
       data.books.map((book) => {
         // 検索結果が別のISBNの場合には無視する
         if (book.id.indexOf('-') === -1 && book.id !== this.props.book.id) {
           return
         }
-        book_deep.holdings = [...book_deep.holdings, ...book.holdings];
+        deep.holdings = [...deep.holdings, ...book.holdings];
         for (let id in book.url) {
           if (Object.prototype.hasOwnProperty.call(book.url, id)) {
-            if (!book_deep.url.hasOwnProperty(id)) {
-              book_deep.url[id] = book.url[id];
-              book_deep.bid[id] = book.id;
+            if (!deep.url.hasOwnProperty(id)) {
+              deep.url[id] = book.url[id];
+              deep.bid[id] = book.id;
             }
           }
         }
       })
+      book_deep = deep;
     } else {
       book_deep = null;
     }
@@ -112,6 +118,9 @@ export default class Book extends React.Component<Props, State> {
   }
 
   render() {
+    /* Index の defaultProps が DefaultHoldingView を入れるので実際は必ず渡ってくる */
+    const CustomHoldingView = this.props.customHoldingView!;
+
     /* 有効な所蔵情報を集約する
      * ・現在Deep検索中（またはエラー）で、推定所蔵データがあるものは追加
      * ・すべての確定所蔵は追加
@@ -140,8 +149,8 @@ export default class Book extends React.Component<Props, State> {
                ((this.props.book.publisher) ? "出版者。" + this.props.book.publisher + "。" : "") +
                ((this.props.book.pubdate) ? "出版年。" + this.props.book.pubdate + "。" : "") +
                ((this.props.book.isbn === '' || this.props.book.isbn === null) ? '' : 'ISBNあり。'))}
-           onKeyUp={!this.props.opened ? this.onKeyUp.bind(this) : null}
-           onClick={!this.props.opened ? this.props.onSelect.bind(this) : null}>
+           onKeyUp={!this.props.opened ? this.onKeyUp.bind(this) : undefined}
+           onClick={!this.props.opened ? this.props.onSelect.bind(this) : undefined}>
         {(() => {
           if (this.props.coverImage) {
             return (
@@ -284,7 +293,7 @@ export default class Book extends React.Component<Props, State> {
                       if (url && this.props.holdingLinkReplacer) url = this.props.holdingLinkReplacer(url);
 
                       return (
-                        <this.props.customHoldingView url={url}
+                        <CustomHoldingView url={url}
                                                       key={holding}
                                                       uuid={uuid}
                                                       libid={holding}

--- a/src/js/view/index.tsx
+++ b/src/js/view/index.tsx
@@ -57,13 +57,13 @@ type Props = {
   lazyHidden?: Array<string>, // 遅い検索対象を隠す(システムIDを指定)
   rows: number, // 検索結果の行数
   holdingLinkReplacer?: Function, // 所蔵リンクの置換関数
-  holdingOrder?: Array<number>, // 所蔵リンクの並び順(nullの場合はソートしない)
+  holdingOrder?: Array<number> | null, // 所蔵リンクの並び順(nullの場合はソートしない)
   showLogo: boolean, // ロゴを表示するか
   linkLogo: boolean, // ロゴにリンクするか
   filterTitle?: string, // フィルタのタイトル
   customHoldingView?: React.ComponentType<any>, // カスタム所蔵コンポーネント
   customDetailView?: React.ComponentType<any>, // カスタム資料コンポーネント
-  onSearch?: Function, // 検索イベント
+  onSearch?: Function | null, // 検索イベント
   customNotFoundView?: React.ComponentType<any>, // 見つからないときの表示
   externalLinks: Array<UIExternal>, // 外部サービスへの連携リンク
   welcomeMessage: string | React.ComponentType<any> | null | undefined,
@@ -111,7 +111,7 @@ export default class Index extends React.Component<Props, State> {
     super(props);
     let params = getParamsFromURL();
     let filterItem = getFilter(props.filters, params.filter);
-    let mapping = {};
+    let mapping: { [key: string]: UnitradMapping } = {};
     mapping[this.props.region] = {
       name_to_id: props.name_to_id ? props.name_to_id : {},
       libraries: props.libraries ? props.libraries : {}
@@ -142,7 +142,7 @@ export default class Index extends React.Component<Props, State> {
 
   componentDidMount() {
     window.pressKey = this.boundOnPressKey;
-    if (typeof history !== 'undefined' && history.pushState && history.state !== undefined) {
+    if (typeof history !== 'undefined' && typeof history.pushState === 'function' && history.state !== undefined) {
       window.addEventListener('popstate', this.boundOnPopState);
     }
     window.addEventListener("scroll", this.boundOnScroll);

--- a/src/js/view/result.tsx
+++ b/src/js/view/result.tsx
@@ -84,7 +84,7 @@ export default class Results extends React.Component<Props, State> {
       sort_column: '',
       sort_order: '',
       sort_class: [],
-      region: null
+      region: ''
     };
   }
 
@@ -123,12 +123,13 @@ export default class Results extends React.Component<Props, State> {
   }
 
   onSelectBook(e: React.SyntheticEvent) {
-    if (window.getSelection().toString() !== '') return; // 選択中はクリックを処理しない
+    if (window.getSelection()!.toString() !== '') return; // 選択中はクリックを処理しない
     let current: Element | null | undefined = e.target as Element;
     while (current && current.parentNode) {
-      if (current.attributes.getNamedItem('data-id')) {
-        let hash = current.attributes.getNamedItem('data-id').value;
-        if (history.pushState && history.state !== undefined) {
+      const dataId = current.attributes.getNamedItem('data-id');
+      if (dataId) {
+        let hash = dataId.value;
+        if (typeof history.pushState === 'function' && history.state !== undefined) {
           history.pushState('selected_id', '', location.pathname + location.search + '#' + hash);
         }
         this.setState({'selected_id': hash});
@@ -141,7 +142,7 @@ export default class Results extends React.Component<Props, State> {
   // #(hash)を消す
   removeHash() {
     if (location.hash !== '') {
-      if (history.pushState && history.state !== undefined) {
+      if (typeof history.pushState === 'function' && history.state !== undefined) {
         history.replaceState('search', '', location.pathname + location.search);
       } else {
         location.hash = '';
@@ -169,7 +170,7 @@ export default class Results extends React.Component<Props, State> {
     let names = ['triangle'];
     let column = target && target.dataset ? target.dataset.sortColumn : null;
     if (typeof column !== 'string') return;
-    const firstOrders = {
+    const firstOrders: { [key: string]: 'ascend' | 'descend' } = {
       title: 'ascend',
       author: 'ascend',
       publisher: 'ascend',
@@ -177,7 +178,7 @@ export default class Results extends React.Component<Props, State> {
       isbn: 'ascend',
       holdings: 'descend'
     };
-    let nextOrder;
+    let nextOrder: '' | 'ascend' | 'descend';
     let currentOrder: string = (this.state.sort_column === column) ? this.state.sort_order : '';
     if (currentOrder === '') {
       nextOrder = firstOrders[column];
@@ -206,7 +207,7 @@ export default class Results extends React.Component<Props, State> {
   }
 
   render() {
-    let _books = [];
+    let _books: Array<UnitradBook> = [];
     let message: string = '';
     let notfound = false;
     let complete = false;
@@ -318,7 +319,7 @@ export default class Results extends React.Component<Props, State> {
           </div>
           <div
             className={classNames.join(' ')}
-            aria-busy={this.state.result && this.state.result.running}
+            aria-busy={this.state.result ? this.state.result.running : undefined}
             aria-rowcount={_books.length}
             aria-readonly="true"
             role="grid">

--- a/test/test_api.mts
+++ b/test/test_api.mts
@@ -52,8 +52,8 @@ describe('Support Functions', () => {
     it('リージョンのみ指定する', () => assert.equal(isEmptyQuery({region: "kyoto"}), true));
   });
   describe('#isEqualQuery', () => {
-    it('undefined==空', () => assert.equal(isEqualQuery(undefined as any, {}), true));
-    it('undefined!=タイトル', () => assert.equal(isEqualQuery(undefined as any, {title: "テスト"}), false));
+    it('undefined==空', () => assert.equal(isEqualQuery(undefined, {}), true));
+    it('undefined!=タイトル', () => assert.equal(isEqualQuery(undefined, {title: "テスト"}), false));
     it('空==空', () => assert.equal(isEqualQuery({}, {}), true));
     it('タイトル!=空', () => assert.equal(isEqualQuery({title: "テスト"}, {}), false));
     it('タイトル==タイトル', () => assert.equal(isEqualQuery({title: "テスト"}, {title: "テスト"}), true));
@@ -190,7 +190,8 @@ describe('APIの通信', () => {
       const instance = new api({free: 'x'} as any, (d) => { received = d; });
       await flush();
       assert.equal(fetched.length, 1, '1回目が失敗している');
-      assert.equal(received, null);
+      /* assert.equal は表明関数なので received を null に絞り込んでしまう。ok で受ける */
+      assert.ok(received === null, '1回目では受け取っていない');
       mock.timers.tick(1000);
       await flush();
       instance.kill();

--- a/test/test_sort.mts
+++ b/test/test_sort.mts
@@ -40,7 +40,7 @@ describe('出版年の処理', () => {
     it('昭和元年', () => assert.equal(normalizePubdate("昭和元年"), 19260000));
     it('[20--]', () => assert.equal(normalizePubdate("[20--]"), 20000000));
     it('空白文字', () => assert.equal(normalizePubdate(""), 0));
-    it('Null', () => assert.equal(normalizePubdate(null as any), 0));
+    it('Null', () => assert.equal(normalizePubdate(null), 0));
     it('Windows', () => assert.equal(normalizePubdate("Windows"), 0));
     it('令和元年', () => assert.equal(normalizePubdate("令和元年"), 20190000));
     it('平成31年', () => assert.equal(normalizePubdate("平成31年"), 20190000));
@@ -57,7 +57,7 @@ describe('ISBNの正規化', () => {
   /* 10桁以下は13桁と桁を揃えるため、EN SPACE 3つを頭に付けて文字列ソートを成立させる */
   it('10桁は先頭にEN SPACEを3つ付ける', () => assert.equal(normalizeIsbn('4000000000'), '   ' + '4000000000'));
   it('空文字は空文字', () => assert.equal(normalizeIsbn(''), ''));
-  it('undefinedは空文字', () => assert.equal(normalizeIsbn(undefined as any), ''));
+  it('undefinedは空文字', () => assert.equal(normalizeIsbn(undefined), ''));
 });
 
 describe('所蔵の絞り込み', () => {
@@ -111,7 +111,7 @@ describe('所蔵の絞り込み', () => {
   describe('# intersectHoldings', () => {
     it('共通部分を返す', () => assert.deepEqual(intersectHoldings([1, 2, 3], [2, 3, 4]), [2, 3]));
     it('共通がなければ空', () => assert.deepEqual(intersectHoldings([1], [2]), []));
-    it('片方がnullなら空', () => assert.deepEqual(intersectHoldings(null as any, [1]), []));
+    it('片方がnullなら空', () => assert.deepEqual(intersectHoldings(null, [1]), []));
   });
 });
 
@@ -129,13 +129,16 @@ describe('検索中の館の絞り込み', () => {
   });
 
   describe('# unresolvedHoldings', () => {
-    const data = {remains: ['A図書館'], errors: ['B図書館']} as UnitradResult;
+    /** 検索結果を作る。remainsとerrorsだけ差し替える */
+    const result = (remains: Array<string>, errors: Array<string>): UnitradResult => ({
+      uuid: 'u1', version: 1, running: false, books: [], remains, errors
+    });
     it('remainsとerrorsの図書館IDを集める', () =>
-      assert.deepEqual(unresolvedHoldings(data, name_to_id), [1, 2, 3]));
+      assert.deepEqual(unresolvedHoldings(result(['A図書館'], ['B図書館']), name_to_id), [1, 2, 3]));
     it('重複は1回だけ', () =>
-      assert.deepEqual(unresolvedHoldings({remains: ['A図書館'], errors: ['A図書館']} as UnitradResult, name_to_id), [1, 2]));
+      assert.deepEqual(unresolvedHoldings(result(['A図書館'], ['A図書館']), name_to_id), [1, 2]));
     it('未知の館は無視する', () =>
-      assert.deepEqual(unresolvedHoldings({remains: ['不明館'], errors: []} as UnitradResult, name_to_id), []));
+      assert.deepEqual(unresolvedHoldings(result(['不明館'], []), name_to_id), []));
   });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,13 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "strict": false,
-    "noImplicitAny": false
+
+    // strictPropertyInitialization だけ残件がある（5件）。api.ts の data、book.tsx の api、
+    // result.tsx の _query / api / started で、いずれも constructor ではなく
+    // componentDidMount や doDeepSearch で代入される。定義代入アサーションで黙らせるより、
+    // 実際に undefined を取りうることを型で認めて呼び出し側を直すのが筋なので、別途行う。
+    "strict": true,
+    "strictPropertyInitialization": false
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## 概要

[unitrad-view #106](https://github.com/CALIL/unitrad-view/pull/106) の展開です。動作は変わりません。

**base は #79 です。** #79 がマージされると自動で `master` に付け替わります。

これまで `strict: false` / `noImplicitAny: false` でした。潰すと残りは `strictPropertyInitialization` の5件だけになったので `strict` まで上げます。

## 実際のバグに近いもの

**`history.pushState` を真偽値で見ている箇所で TS2774（この条件は常に true になる）と指摘されました。** lib の型では常に定義されているためです。古いブラウザ向けの機能検出の名残なので、意図を残したまま `typeof history.pushState === 'function'` に書き換えます。`pushState` を持たないブラウザでは `history.state` も undefined なので、後段の判定で同じ分岐に入ります。

`result.tsx` の `getNamedItem('data-id')` を、存在確認と値の取得で2回呼んでいました。`const` に受けて1回にします。

## 型を実態に合わせたもの

| 対象 | 変更 | 根拠 |
|---|---|---|
| `_stringSorter` / `normalizeIsbn` / `intersectHoldings` / `isEqualQuery` / `normalizePubdate` | 引数に null と undefined を許す | いずれも実行時に falsy を処理している |
| `Index.Props.holdingOrder` / `onSearch` | `\| null` を許す | `defaultProps` が null を入れている |
| `Book.state.book_deep` | `UnitradBook` から `BookDeep` へ | 実際に入るのは url・holdings・bid だけの集約。unitrad-ui-nagano に既にある同名の型に揃えた |

## 型の穴を塞いだもの

**`customHoldingView` だけが JSX で直接使われていて、`customDetailView` や `customNotFoundView` のようなガードがありませんでした。** `Index` の `defaultProps` が `DefaultHoldingView` を入れるので実際は必ず渡ってきます。`render` の先頭で `const` に受けます。

`firstOrders` と `mapping` と `_books` に型注釈がなく、string での添字参照が暗黙の any になっていました。

## テスト側

`test_view.tsx` / `test_api.mts` / `test_sort.mts` を unitrad-view と同じ内容にしました。`isEqualQuery` / `normalizePubdate` / `normalizeIsbn` / `intersectHoldings` にかけていた `as any` は、シグネチャを直したので外しています。**テストが実際に検証している入力が、型の上でも通るようになります。**

`assert.equal` は表明関数なので、`received` を null と比較した時点で以降が絞り込まれる件も含みます。`jsdom` が型定義を同梱していないため `@types/jsdom` を足します。

## 残した1つ

**`strictPropertyInitialization` だけ false のままにします。** `api.ts` の `data`、`book.tsx` の `api`、`result.tsx` の `_query` / `api` / `started` の5件で、いずれも constructor ではなく `componentDidMount` や `doDeepSearch` で代入されます。理由は `tsconfig.json` にも書きました。

## 動作は変わりません

前後のバンドルを比較しました。**`#app` の DOM は2905文字で完全一致**、エラーもありません。`app.js` は 193971 → 194072 バイトになります。増えた分は型を通すために足したコードです。

## 検証

- `npm run typecheck`（src と test の両方）
- `npm test` 190件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsERiWbzZwB6EdGoyyqcpT