### PR TITLE
strictPropertyInitialization を有効化する

### DIFF
--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -35,7 +35,7 @@ export class api {
    */
   callback: (data: UnitradResult) => void;
   killed: boolean;
-  data: UnitradResult;
+  data: UnitradResult | undefined;
 
   constructor(query: UnitradQuery, callback: (data: UnitradResult) => void) {
     this.callback = callback;
@@ -64,6 +64,7 @@ export class api {
 
   polling() {
     if (!this.killed) {
+      if (!this.data) return;
       _request('polling')
         .query({
           uuid: this.data.uuid,
@@ -84,6 +85,7 @@ export class api {
   receive(data: UnitradResult) {
     if (!this.killed) {
       if (data.books_diff) {
+        if (!this.data) return;
         Array.prototype.push.apply(this.data.books, data.books_diff.insert);
         for (const key in data) {
           if (hasOwn(data, key) && key !== 'books_diff') {

--- a/src/js/view/book.tsx
+++ b/src/js/view/book.tsx
@@ -48,7 +48,7 @@ type Props = {
 }
 
 export default class Book extends React.Component<Props, State> {
-  api: api;
+  api: api | undefined;
   deep_requested: boolean = false;
   state: State = {
     uuid: null,

--- a/src/js/view/result.tsx
+++ b/src/js/view/result.tsx
@@ -70,9 +70,9 @@ type Props = {
 
 
 export default class Results extends React.Component<Props, State> {
-  _query: UnitradQuery;
-  api: api;
-  started: number;
+  _query: UnitradQuery | undefined;
+  api: api | undefined;
+  started: number | undefined;
   ariaTime: number | null | undefined;
 
   constructor(props: Props) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,12 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
 
-    // strictPropertyInitialization だけ残件がある（5件）。api.ts の data、book.tsx の api、
-    // result.tsx の _query / api / started で、いずれも constructor ではなく
-    // componentDidMount や doDeepSearch で代入される。定義代入アサーションで黙らせるより、
-    // 実際に undefined を取りうることを型で認めて呼び出し側を直すのが筋なので、別途行う。
-    "strict": true,
-    "strictPropertyInitialization": false
+    "strict": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## 概要

`tsconfig.json` で個別に無効化していた `strictPropertyInitialization` を外し、`strict: true` に含めて有効化しました。残っていた5件を解消しています。

同じ作業を **unitrad-view の PR #107** で先に行っており、**その差分を正本として展開したもの**です。

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/js/api.ts` | `data` を `UnitradResult \| undefined` に。`polling()` と `receive()` の `books_diff` 側にガードを1行ずつ追加 |
| `src/js/view/book.tsx` | `api` を `api \| undefined` に |
| `src/js/view/result.tsx` | `_query` / `api` / `started` を `\| undefined` に |
| `tsconfig.json` | `strictPropertyInitialization: false` と経緯コメントを削除 |

いずれも `constructor` ではなく `componentDidMount` や `doDeepSearch` で代入されるプロパティです。定義代入アサーション（`data!: T`）で黙らせるのではなく、実際に `undefined` を取りうることを型で認めて呼び出し側を直す方針にしました。

宣言だけ直せば通る4件（`book.tsx` の `api`、`result.tsx` の3件）は、呼び出し側が元から `if (this.api)` などでガード済みだったため型の変更だけで済んでいます。`api.ts` の `data` だけは `polling()` と `receive()` の `books_diff` 側が無条件に参照していたため、ガードを追加しました。

`receive()` のガードは `if (data.books_diff)` の枝の中に置いています。関数の先頭に上げると初回受信が return して検索結果が入らなくなるためです。どちらのガードも `this.data` が入る前には到達しないので、実際の動きは変わりません。

## unitrad-view との差異

- `src/js/api.ts` / `src/js/view/result.tsx` / `tsconfig.json` … unitrad-view と**バイト同一**だったため、正本の差分をそのまま適用できました
- `src/js/view/book.tsx` … unitrad-view とは内容が異なります（あちらには砺波市の所蔵館数の例外処理、白河市向けの書影表示、横浜市・山口向けのカスタマイズなどが入っています）。ただし `api` プロパティの宣言と使われ方は同じで、変更箇所も宣言1行だけでした
- **正本に無い追加のエラーは出ていません**

## 検証

- `npm run typecheck`（`tsc --noEmit` と `tsc --noEmit -p tsconfig.test.json`）… エラー0件
- `npm test` … 190件すべてパス
- `npm run release` … 成功。ビルド成果物は `assets` / `index.html` / `app.css` がハッシュ一致。`app.js` のみ 194085 → 194132 バイトの差分があり、中身は追加したガード2行と、それに伴って esbuild が `polling()` の単文 `if` を短絡形（`this.killed||…`）からブロック形へ戻した分だけでした

型の厳格化のみで、挙動は変えていません。
