### PR TITLE
chore(deps): @types/node のメジャー更新を Dependabot の対象外にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,16 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@types/react-dom"
         update-types: ["version-update:semver-major"]
+      # @types/node のメジャーは Node.js 本体のメジャーに対応しているので、
+      # サポート下限（package.json の engines = >=22）より先に上げてはいけない。
+      # 上げると新しい Node.js で追加された API を tsc が通してしまい、
+      # engines を満たすはずの Node.js 22 環境で初めて落ちる。
+      #
+      # CI では気づけない。node-version-file が engines の >=22 を解決するので
+      # ランナーには最新の 24 系が入り、22 では無い API も動いてしまう。
+      # Node.js を上げるときに engines と一緒に手で上げる。
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         patterns:


### PR DESCRIPTION
## 何をしたか

`.github/dependabot.yml` の npm の `ignore` に `@types/node` のメジャー更新を追加しました。

## なぜ

`@types/node` のメジャーは Node.js 本体のメジャーに対応しています。このリポジトリの
サポート下限は `package.json` の `engines.node` = `>=22` なので、型だけ先に上げると
**Node.js 24 以降で追加された API を `tsc` が通してしまい、`engines` を満たすはずの
Node.js 22 環境で初めて落ちます。**

### CI では気づけない

`ci.yml` の `node-version-file` は `.nvmrc` が無いので `package.json` を見ますが、
`engines` の `>=22` はランナー上で**最新の 24 系に解決されます**（実測 v24.19.0）。
つまり CI は下限の Node.js 22 を一度も踏んでいないため、型と実行環境の乖離を
検出できません。「CI がグリーンだから安全」が成立しないケースです。

### 実際に取り残されていた

2026-08-17 時点で org 内の 14 リポジトリは同じ `ignore` を持っていますが、
このリポジトリには入っていませんでした。そのため `@types/node` を
`22.20.1` → `26.1.1` へ上げる Dependabot PR が CI グリーンで開いていました
（この PR のマージ後にクローズします）。

## 影響範囲

Dependabot の設定のみで、ソースとビルドには一切触っていません。マイナー・パッチの
`@types/node` 更新は従来どおり `npm-minor-patch` グループで届きます。止まるのは
メジャーだけです。

Node.js を上げるときは `engines` と `@types/node` を一緒に手で上げてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
