### PR TITLE
chore(deps): React 19 に上げる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,16 +30,6 @@ updates:
       default-days: 7
       semver-major-days: 30
     ignore:
-      # react のメジャー更新は周辺ライブラリの対応状況をまとめて確認してから
-      # 手動で判断する。詳細は Todoist を参照
-      - dependency-name: "react"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "react-dom"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/react"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/react-dom"
-        update-types: ["version-update:semver-major"]
       # @types/node のメジャーは Node.js 本体のメジャーに対応しているので、
       # サポート下限（package.json の engines = >=22）より先に上げてはいけない。
       # 上げると新しい Node.js で追加された API を tsc が通してしまい、

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "react-paginate": "8.3.0"
       },
       "devDependencies": {
         "@types/jsdom": "^30.0.0",
         "@types/node": "^22.20.1",
-        "@types/react": "^18.3.31",
-        "@types/react-dom": "^18.3.7",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
         "autoprefixer": "^10.5.4",
         "browserslist": "^4.28.8",
         "cssnano": "^7.1.9",
@@ -1064,32 +1064,24 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -2820,28 +2812,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -3385,13 +3373,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "devDependencies": {
     "@types/jsdom": "^30.0.0",
     "@types/node": "^22.20.1",
-    "@types/react": "^18.3.31",
-    "@types/react-dom": "^18.3.7",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
     "autoprefixer": "^10.5.4",
     "browserslist": "^4.28.8",
     "cssnano": "^7.1.9",
@@ -41,8 +41,8 @@
   },
   "homepage": "https://github.com/CALIL/unitrad-ui#readme",
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "react-paginate": "8.3.0"
   },
   "overrides": {


### PR DESCRIPTION
`react` / `react-dom` / `@types/react` / `@types/react-dom` を 19 系にします。

```
react / react-dom   ^18.3.1  → ^19.2.8
@types/react        ^18.3.31 → ^19.2.18
@types/react-dom    ^18.3.7  → ^19.2.4
```

あわせて `.github/dependabot.yml` の react 4件の ignore を外しました。2026-08-04 に
「周辺ライブラリの対応状況をまとめて確認してから手動で判断する」として入れたものです。
確認が済んだので役目を終えます（unitrad-view も 19 化時に同じ ignore を外しています）。

## 下ごしらえは済んでいます

本体は `findDOMNode` / 文字列 ref / `this.refs` が**いずれも0件**です。2026-08-09 の
createRef 化展開（#77）で潰し済みでした。

`react-paginate` は 8.3.0 のままです。unitrad-view が同じ版を React 19 で本番稼働させて
いるので据え置きました。`npm ls` でも 19.2.8 に解決されています。

## 確認

`npm run typecheck`（`tsc --noEmit` ×2）と `npm test` がグリーンです。

```
tests 190 / pass 190 / fail 0
```

`test_view.tsx` は jsdom + createRoot でマウントするので、React 19 で壊れる典型
（文字列 ref の例外、`findDOMNode` の TypeError）はここで止まります。ビルドの成否では
判定していません。

`npm run release` も通り、esbuild のターゲットは chrome147 / edge147 / firefox140 /
ios18.5 / opera80 / safari26 のままです。

## バンドルは +51KB 増えます

同じ worktree で 18 と 19 を切り替えて実測しました。

| | raw | gzip |
|---|---|---|
| React 18 | 194,132 | 60,965 |
| React 19 | 245,302 | 75,756 |
| 差分 | **+51,170（+26.4%）** | **+14,791（+24.3%）** |

unitrad-view の実測（+25.7% / gzip +14KB）とほぼ一致します。増分はほぼ `react-dom` 単独で、
ツリーシェイクでは削れません（`react-dom` は CJS のみ配布で `module` フィールドが無い）。
React 側から回避策は示されていないので、飲むしかない増加です。

回収したい場合は preact/compat が選択肢になりますが、これは 19 移行とは独立した判断なので
このPRには含めません。

## このPRの位置づけ

org 内で React 18 が残っているのは Unitrad 系の5リポジトリだけで、その先頭がここです。
src の24ファイル中19件が unitrad-view とバイト同一なので、実証済みの変更を当てるだけに
なります。残りは unitrad-kintone-plugin → touch-unitrad-module → unitrad-ui-nagano →
unitrad-ojiya の順で、後ろ2つはマウントテストの追加が前段に要ります。
